### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/rudes/runestats.svg?branch=master)](https://travis-ci.org/rudes/runestats)
 [![Code Climate](https://codeclimate.com/github/rudes/runestats/badges/gpa.svg)](https://codeclimate.com/github/rudes/runestats)
 [![GoDoc](https://godoc.org/github.com/rudes/runestats?status.svg)](https://godoc.org/github.com/rudes/runestats)
-[![Docker Automated build](https://img.shields.io/docker/automated/rudes/runestats.svg?maxAge=2592000?style=plastic)](https://hub.docker.com/r/rudes/runestats)
+[![Docker Automated build](https://img.shields.io/docker/automated/rudes/runestats.svg?maxAge=2592000?style=plastic)](https://hub.docker.com/r/rudes/runestats) [![](https://images.microbadger.com/badges/image/rudes/runestats.svg)](https://microbadger.com/images/rudes/runestats "Get your own image badge on microbadger.com")
 [![Coverage Status](https://coveralls.io/repos/github/rudes/runestats/badge.svg?branch=master)](https://coveralls.io/github/rudes/runestats?branch=master)
 
 [Runescape](http://www.runescape.com/) [Stat](http://runestats.stream/) page for twitch.
@@ -30,3 +30,4 @@ character [Niriviaa](http://services.runescape.com/m=hiscore_oldschool/hiscorepe
 
 Runestats is licensed under the Apache License, Version 2.0. 
 See [LICENSE](https://github.com/rudes/runestats/blob/master/LICENSE) for the full text.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [rudes/runestats](https://hub.docker.com/r/rudes/runestats/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/rudes/runestats).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/rudes/runestats.svg)](https://microbadger.com/images/rudes/runestats)
